### PR TITLE
Handle multiple stop calls to identical subs gracefully

### DIFF
--- a/src/subsCache.coffee
+++ b/src/subsCache.coffee
@@ -103,7 +103,7 @@ class @SubsCache
           expireTime: expireTime
           when: null
           callbacks: []
-          timesCalled: 1
+          copies: 1
           ready: ->
             @sub.ready()
           onReady: (callback)->
@@ -132,17 +132,16 @@ class @SubsCache
             #  catch err
             #    console.info 'Warning! SubsCache ignoring exception:', err.message
           stop: ->
-            if @timesCalled <= 1
+            @copies--
+            if @copies == 0
               @delayedStop()
-            else
-              @timesCalled--
           delayedStop: ->
             if expireTime >= 0
               @timerId = setTimeout(@stopNow.bind(this), expireTime*1000*60)
           restart: ->
             # if we'are restarting, then stop the timer
             clearTimeout(@timerId)
-            @timesCalled++
+            @copies++
             @start()
           stopNow: ->
             @sub.stop()

--- a/src/subsCache.coffee
+++ b/src/subsCache.coffee
@@ -138,7 +138,6 @@ class @SubsCache
               @count--
           delayedStop: ->
             if expireTime >= 0
-              console.info("Beginning delayed stop:", this)
               @timerId = setTimeout(@stopNow.bind(this), expireTime*1000*60)
           restart: ->
             # if we'are restarting, then stop the timer
@@ -146,7 +145,6 @@ class @SubsCache
             @count++
             @start()
           stopNow: ->
-            console.info("Stopping:", this)
             @sub.stop()
             delete cache[@hash]
 
@@ -154,10 +152,7 @@ class @SubsCache
         newArgs = withoutCallbacks args
         newArgs.push cachedSub.getDelegatingCallbacks()
         # make sure the subscription won't be stopped if we are in a reactive computation
-        cachedSub.sub = Tracker.nonreactive ->
-          console.info("Subscribing:", newArgs)
-          Meteor.subscribe.apply(Meteor, newArgs)
-
+        cachedSub.sub = Tracker.nonreactive -> Meteor.subscribe.apply(Meteor, newArgs)
 
         if hasCallbacks args
           cachedSub.registerCallbacks callbacksFromArgs args

--- a/src/subsCache.coffee
+++ b/src/subsCache.coffee
@@ -133,12 +133,14 @@ class @SubsCache
           stop: -> @delayedStop()
           delayedStop: ->
             if expireTime >= 0
+              console.info("Beginning delayed stop:", this)
               @timerId = setTimeout(@stopNow.bind(this), expireTime*1000*60)
           restart: ->
             # if we'are restarting, then stop the timer
             clearTimeout(@timerId)
             @start()
           stopNow: ->
+            console.info("Stopping:", this)
             @sub.stop()
             delete cache[@hash]
 
@@ -146,7 +148,10 @@ class @SubsCache
         newArgs = withoutCallbacks args
         newArgs.push cachedSub.getDelegatingCallbacks()
         # make sure the subscription won't be stopped if we are in a reactive computation
-        cachedSub.sub = Tracker.nonreactive -> Meteor.subscribe.apply(Meteor, newArgs)
+        cachedSub.sub = Tracker.nonreactive ->
+          console.info("Subscribing:", newArgs)
+          Meteor.subscribe.apply(Meteor, newArgs)
+
 
         if hasCallbacks args
           cachedSub.registerCallbacks callbacksFromArgs args

--- a/src/subsCache.coffee
+++ b/src/subsCache.coffee
@@ -103,7 +103,7 @@ class @SubsCache
           expireTime: expireTime
           when: null
           callbacks: []
-          count: 0
+          timesCalled: 1
           ready: ->
             @sub.ready()
           onReady: (callback)->
@@ -132,17 +132,17 @@ class @SubsCache
             #  catch err
             #    console.info 'Warning! SubsCache ignoring exception:', err.message
           stop: ->
-            if @count <= 0
+            if @timesCalled <= 1
               @delayedStop()
             else
-              @count--
+              @timesCalled--
           delayedStop: ->
             if expireTime >= 0
               @timerId = setTimeout(@stopNow.bind(this), expireTime*1000*60)
           restart: ->
             # if we'are restarting, then stop the timer
             clearTimeout(@timerId)
-            @count++
+            @timesCalled++
             @start()
           stopNow: ->
             @sub.stop()

--- a/src/subsCache.coffee
+++ b/src/subsCache.coffee
@@ -103,6 +103,7 @@ class @SubsCache
           expireTime: expireTime
           when: null
           callbacks: []
+          count: 0
           ready: ->
             @sub.ready()
           onReady: (callback)->
@@ -130,7 +131,11 @@ class @SubsCache
               @delayedStop()
             #  catch err
             #    console.info 'Warning! SubsCache ignoring exception:', err.message
-          stop: -> @delayedStop()
+          stop: ->
+            if @count <= 0
+              @delayedStop()
+            else
+              @count--
           delayedStop: ->
             if expireTime >= 0
               console.info("Beginning delayed stop:", this)
@@ -138,6 +143,7 @@ class @SubsCache
           restart: ->
             # if we'are restarting, then stop the timer
             clearTimeout(@timerId)
+            @count++
             @start()
           stopNow: ->
             console.info("Stopping:", this)


### PR DESCRIPTION
## The Problem

Right now when two or more identical subs are made and then one of them is stopped this package stops both/all of the subs.
## The Solution

The solution is to keep track of how many times a sub is `started` and then only stop for real when `stop()` has been called the same number of times as `start()` has.  This is basically reference counting for subs.
